### PR TITLE
Add workaround for bug where navigating to feed page would be stuck loading

### DIFF
--- a/app/src/components/ChannelList.tsx
+++ b/app/src/components/ChannelList.tsx
@@ -21,6 +21,9 @@ const ChannelList: React.FC<{}> = () => {
 
   const channelId = useSelectedChannel();
 
+  // NOTE: intentionally using href over routerLink in the IonItem components below.
+  // It is a workaround for the infinite loading of useQuery when navigating to
+  // a channel.
   return (
     <>
       <IonToast isOpen={!!error} message={error?.message} duration={2000} />


### PR DESCRIPTION
#### Description
- Channel selector uses href instead of routerLink to switch between channels. This is not ideal because it reloads the page instead of using clientside routing, but it provides a workaround for the bug for the mean while. I'm not sure whether we want to go with this change, if people have ideas them I'm happy to hear them.

#### Review Checklist
- [ ] The requirements on the description have been met
- [ ] The relevant documentation has been updated:
    - [ ] code comments for classes / methods / complex statements
    - [ ] package readme
    - [ ] documentation for high level approaches or product info
- [ ] Tests:
    - [ ] new tests written
    - [ ] existing affected tests updated
    - [ ] all green and passing
- [ ] Tested by reviewer
